### PR TITLE
Make webhooks an issueTracker plugin.

### DIFF
--- a/plugins/webhook/config.json
+++ b/plugins/webhook/config.json
@@ -4,6 +4,7 @@
     "create": "Post to a Webhook URL"
   },
   "supportedTriggers": "all",
+  "type": "issueTracker",
   "fields": [
     {
       "name": "url",


### PR DESCRIPTION
This makes it possible to use webhooks as an issue tracking service, using bugsnag as a staging area for issues.
