### PR TITLE
Implement Gitlab search api endpoint

### DIFF
--- a/plugins/gitlab-issues/index.coffee
+++ b/plugins/gitlab-issues/index.coffee
@@ -3,7 +3,7 @@ NotificationPlugin = require "../../notification-plugin"
 class GitLabIssue extends NotificationPlugin
   @getProject: (config, cb) =>
     @request
-      .get("#{config.gitlab_url}/api/v3/projects/?per_page=100")
+      .get("#{config.gitlab_url}/api/v3/projects/search/#{config.project_id.replace('.', '_')}?per_page=10")
       .timeout(4000)
       .set("User-Agent", "Bugsnag")
       .set("PRIVATE-TOKEN", config.private_token)


### PR DESCRIPTION
Change implements Gitlab v3 search api endpoint.
I made couple tests on my Gitlab 6.6.5.

Gitlab project names could contain letters, digits, "-", "_", "." and spaces.

``` bash
coffee index.coffee --private_token="HIDDEN" --gitlab_url="HIDDEN" --project_id="Gitlab123 _7-8.9" - Pass
coffee index.coffee --private_token="HIDDEN" --gitlab_url="HIDDEN" --project_id="Gitlab Test1" - Pass, in this case the Repository name was modified to "test_123-.2"
```

and couple not test projects, which pass to.

Search is based on "Project name" which is internal for Gitlab.

There is still some false positive results, but because of Gitlab sorting.
If you have a project "domain.com" and "domain.com-bak" then project "domain.com-bak" is selected.
