### PR TITLE
Add tags to GitLab issues

### DIFF
--- a/plugins/gitlab-issues/config.json
+++ b/plugins/gitlab-issues/config.json
@@ -22,6 +22,13 @@
       "name": "project_id",
       "label": "Repository Name",
       "description": "Which GitLab repository to create the issue on, eg rails/rails"
+    },
+    {
+      "name": "labels",
+      "label": "Labels (comma separated)",
+      "description": "Comma separated list of labels to apply to the issue.",
+      "optional": true,
+      "defaultValue": "bugsnag"
     }
   ]
 }

--- a/plugins/gitlab-issues/index.coffee
+++ b/plugins/gitlab-issues/index.coffee
@@ -25,7 +25,9 @@ class GitLabIssue extends NotificationPlugin
       payload = 
         title: @title(event)
         description: @markdownBody(event)
-        labels: "bugsnag"
+        # Regex removes surrounding whitespace around commas while retaining inner whitespace
+        # and then creates an array of the strings
+        labels: (config?.labels || "bugsnag").trim().split(/\s*,\s*/).compact(true)
 
       # Send the request
       @request


### PR DESCRIPTION
It is just port from GitHub Plugin. Credits to @jessicard :)

I only made some tests with my GitLab 6.9.0.

``` bash
coffee index.coffee --private_token="HIDDEN" --gitlab_url="HIDDEN" --project_id="Gitlab Test1" --labels="test @$%^&*()_+][}{\|;=-:>?<" - Pass
coffee index.coffee --private_token="HIDDEN" --gitlab_url="HIDDEN" --project_id="Gitlab Test1" --labels="test @$%^&*()_+][}{\|;=-:>?<, tag23456789" - Pass
coffee index.coffee --private_token="HIDDEN" --gitlab_url="HIDDEN" --project_id="Gitlab Test1" --labels="bugsnag, some tag, tag_two_with_dot ." - Pass
```

Resolve #42 
