### PR TITLE
Add app version and/or release stage in GitHub Issues

### DIFF
--- a/plugins/github-issues/config.json
+++ b/plugins/github-issues/config.json
@@ -26,6 +26,22 @@
       "description": "Comma separated list of labels to apply to the issue.",
       "optional": true,
       "defaultValue": "bugsnag"
+    },
+    {
+      "name": "labelAppVersion",
+      "label": "App Version Labeling",
+      "description": "Should we add App Version as issue label",
+      "type": "boolean",
+      "optional": true,
+      "defaultValue": false
+    },
+    {
+      "name": "labelReleaseStage",
+      "label": "Release Stage Labeling",
+      "description": "Should we add Release Stage as issue label",
+      "type": "boolean",
+      "optional": true,
+      "defaultValue": false
     }
   ]
 }

--- a/plugins/github-issues/index.coffee
+++ b/plugins/github-issues/index.coffee
@@ -4,13 +4,21 @@ class GithubIssue extends NotificationPlugin
   BASE_URL = "https://api.github.com"
 
   @receiveEvent: (config, event, callback) ->
+
+    # Create labels variable
+    payloadLabels = (config?.labels || "bugsnag")
+    # Check App Version Labeling
+    payloadLabels += ","+event.error.appVersion if config.labelAppVersion  and event.error.appVersion?
+    # Check Release Stage Labiling
+    payloadLabels += ","+event.error.releaseStage if config.labelReleaseStage and event.error.releaseStage?
+
     # Build the ticket
     payload =
       title: @title(event)
       body: @markdownBody(event)
       # Regex removes surrounding whitespace around commas while retaining inner whitespace
       # and then creates an array of the strings
-      labels: (config?.labels || "bugsnag").trim().split(/\s*,\s*/).compact(true)
+      labels: payloadLabels.trim().split(/\s*,\s*/).compact(true)
 
     # Start building the request
     req = @request


### PR DESCRIPTION
Implement an optional feature to add App Version and / or Release Stage from Exception as labels in GitHub Issue

``` bash
coffee index.coffee --oauthToken="HIDDEN" --repo="drekinov/bugsnag-blank-test-repository" --labels="maybe last" - Pass
coffee index.coffee --oauthToken="HIDDEN" --repo="drekinov/bugsnag-blank-test-repository" --labels="" --labelAppVersion  - Pass
coffee index.coffee --oauthToken="HIDDEN" --repo="drekinov/bugsnag-blank-test-repository" --labels="" --labelReleaseStage - Pass
coffee index.coffee --oauthToken="HIDDEN" --repo="drekinov/bugsnag-blank-test-repository" --labels="" --labelAppVersion --labelReleaseStage - Pass
coffee index.coffee --oauthToken="HIDDEN" --repo="drekinov/bugsnag-blank-test-repository" --labels="bugsnag, test" --labelAppVersion --labelReleaseStage - Pass
```

You can checkout my test repository with test issues: drekinov/bugsnag-blank-test-repository#15

Resolve #41
