### PR TITLE
Configure the Slack Channel that notifications will be sent to

### DIFF
--- a/plugins/slack/config.json
+++ b/plugins/slack/config.json
@@ -11,6 +11,11 @@
       "name": "url",
       "label": "Slack Webhook URL",
       "description": "The Slack webhook URL you would like error data posted to."
+    },
+    {
+      "name": "channel",
+      "label": "Slack Channel",
+      "description": "The name of the Slack Channel you would like the error data posted to."
     }
   ]
 }

--- a/plugins/slack/index.coffee
+++ b/plugins/slack/index.coffee
@@ -27,6 +27,12 @@ class Slack extends NotificationPlugin
       attachments: []
     }
 
+    # Build the channel
+    if config.channel
+      channel = config.channel
+      channel = "#" + channel unless channel.substring(0,1) is "#"
+      payload.channel = channel
+
     # Attach error information
     payload.attachments.push(@errorAttachment(event)) if event.error
 


### PR DESCRIPTION
I finally got a few minutes to put towards adding Channel support to the Slack notification plugin. If a channel is configured, it will be added to the JSON that is sent to the Slack Webhook. I also added some logic to prepend the # if it is missing from the channel configuration in Bugsnag.
