### PR TITLE
Fix assembla tags config

### DIFF
--- a/plugins/assembla/index.coffee
+++ b/plugins/assembla/index.coffee
@@ -38,7 +38,7 @@ class Assembla extends NotificationPlugin
     async.waterfall [getSpace], (err, space) =>
       return callback(err) if err?
 
-      tagNames = config.tags.split(",")
+      tagNames = config.tags?.split(",")
 
       # Build the ticket payload
       payload =


### PR DESCRIPTION
Encountered the following error when attempting to test the Assembla integration via the terminal.

```
Jacobs-MacBook-Pro:assembla Jacob$ coffee index.coffee --space=REMOVED --apiKey=REMOVED --apiSecret=REMOVED

/Users/Jacob/Documents/Bugsnag/Notification-Plugins/plugins/assembla/index.coffee:53
          tagNames = config.tags.split(",");
                                 ^
TypeError: Cannot call method 'split' of undefined
  at /Users/Jacob/Documents/Bugsnag/Notification-Plugins/plugins/assembla/index.coffee:41:30
  at /Users/Jacob/Documents/Bugsnag/Notification-Plugins/plugins/assembla/index.coffee:35:18
  at Request.callback (/Users/Jacob/Documents/Bugsnag/Notification-Plugins/node_modules/superagent/lib/node/index.js:586:3)
  at Request.<anonymous> (/Users/Jacob/Documents/Bugsnag/Notification-Plugins/node_modules/superagent/lib/node/index.js:133:10)
  at Request.emit (events.js:95:17)
  at IncomingMessage.<anonymous> (/Users/Jacob/Documents/Bugsnag/Notification-Plugins/node_modules/superagent/lib/node/index.js:714:12)
  at IncomingMessage.emit (events.js:117:20)
  at _stream_readable.js:929:16
  at process._tickCallback (node.js:419:13)
```

This fixes the issue.
