### PR TITLE
Fix Axosoft

### DIFF
--- a/plugins/axosoft/config.json
+++ b/plugins/axosoft/config.json
@@ -38,8 +38,8 @@
     },
     {
       "name": "username",
-      "label": "Username",
-      "description": "Your Axosoft username"
+      "label": "Login ID",
+      "description": "Your Axosoft login (your email address, by default)"
     },
     {
       "name": "password",

--- a/plugins/axosoft/index.coffee
+++ b/plugins/axosoft/index.coffee
@@ -103,7 +103,7 @@ class Axosoft extends NotificationPlugin
         return callback(err) if err
 
         # Step 3. Create item
-        @postItem config, event, (err) =>
-          return callback(err) if err
+        @postItem config, event, (err, data) =>
+          callback err, data
 
 module.exports = Axosoft


### PR DESCRIPTION
- Added additional explanation to the 'username' field. For me, my username (or internally referred to as 'login id') was my email address.
- Fixed the callback to correctly return the item information.

This was most likely the confusion in @sylveawong's issue https://github.com/bugsnag/bugsnag-notification-plugins/issues/97
