### PR TITLE
Add white space to make Slack recognize the URL.

### DIFF
--- a/plugins/slack/index.coffee
+++ b/plugins/slack/index.coffee
@@ -16,7 +16,7 @@ class Slack extends NotificationPlugin
 
   @receiveEvent = (config, event, callback) ->
     # Build the notification title
-    title = ["#{event.trigger.message} in #{event.error.releaseStage} from <#{event.project.url}|#{event.project.name}>"]
+    title = ["#{event.trigger.message} in #{event.error.releaseStage} from <#{event.project.url} | #{event.project.name}>"]
     title.push("in #{event.error.context}")
     title.push("<#{event.error.url}|(details)>")
 


### PR DESCRIPTION
Hi bugsnag team,

The project URL in the bugsnag notification to Slack is recognized with the project name by Slack. It means the URL becomes incorrect. Please refer to the image below.

![screen shot 2014-08-16 at 11 15 29 pm](https://cloud.githubusercontent.com/assets/1162120/3942026/cd5b4ba4-254f-11e4-8164-b1fbb532b8cb.png)

The URL includes the project name and it leads to invalid URL.
