### PR TITLE
Escape project name in notifications to Slack

### DIFF
--- a/plugins/slack/index.coffee
+++ b/plugins/slack/index.coffee
@@ -16,7 +16,8 @@ class Slack extends NotificationPlugin
 
   @receiveEvent = (config, event, callback) ->
     # Build the notification title
-    title = ["#{event.trigger.message} in #{event.error.releaseStage} from <#{event.project.url}|#{event.project.name}>"]
+    projectName = event.project.name.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    title = ["#{event.trigger.message} in #{event.error.releaseStage} from <#{event.project.url}|#{projectName}>"]
     title.push("in #{event.error.context}")
     title.push("<#{event.error.url}|(details)>")
 


### PR DESCRIPTION
Hi bugsnag team,

We need to escape several characters to notify Slack. Please refer to the [Slack message formatting](https://api.slack.com/docs/formatting).

I also attached what happens without this fix below.

![screen shot 2014-08-16 at 11 15 29 pm](https://cloud.githubusercontent.com/assets/1162120/3942065/6ffe07c8-2552-11e4-97c3-8c016dd1247e.png)
