### PR TITLE
82 pivotal

### DIFF
--- a/plugins/pivotal-tracker/index.coffee
+++ b/plugins/pivotal-tracker/index.coffee
@@ -4,9 +4,48 @@ require "sugar"
 NotificationPlugin = require "../../notification-plugin"
 
 class PivotalTracker extends NotificationPlugin
-  @receiveEvent: (config, event, callback) ->
-    return if event?.trigger?.type == "reopened"
+  BASE_URL = "https://www.pivotaltracker.com/services/v3/projects"
 
+  @storiesUrl: (config) ->
+    "#{BASE_URL}/#{config.projectId}/stories"
+
+  @storyUrl: (config, storyId) ->
+    @storiesUrl(config) + "/" + storyId
+
+  @notesUrl: (config, storyId) ->
+    @storyUrl(config, storyId) + "/notes"
+
+  @ensureIssueOpen: (config, storyId, callback) ->
+    params =
+      "story[current_state]": "unstarted"
+
+    @request
+      .put(@storyUrl(config, storyId))
+      .timeout(4000)
+      .set("X-TrackerToken", config.apiToken)
+      .type("form")
+      .send(params)
+      .buffer(true)
+      .on "error", (err) ->
+        callback(err)
+      .end (res) ->
+        return callback(res.error) if res.error
+
+  @addCommentToIssue: (config, storyId, comment) ->
+    params =
+      "note[text]": comment
+
+    @request
+      .post(@notesUrl(config, storyId))
+      .timeout(4000)
+      .set("X-TrackerToken", config.apiToken)
+      .type("form")
+      .send(params)
+      .buffer(true)
+      .on("error", console.error)
+      .end()
+
+  @openIssue: (config, event, callback) ->
     # Build the request
     params =
       "story[name]": "#{event.error.exceptionClass} in #{event.error.context}".truncate(5000)
@@ -24,7 +63,7 @@ class PivotalTracker extends NotificationPlugin
 
     # Send the request to the url
     @request
-      .post("https://www.pivotaltracker.com/services/v3/projects/#{config.projectId}/stories")
+      .post(@storiesUrl(config))
       .timeout(4000)
       .set("X-TrackerToken", config.apiToken)
       .type("form")
@@ -41,5 +80,13 @@ class PivotalTracker extends NotificationPlugin
           callback null,
             id: result.story.id
             url: result.story.url
+
+  @receiveEvent: (config, event, callback) ->
+    if event?.trigger?.type == "reopened"
+      if event.error?.createdIssue?.id
+        @ensureIssueOpen(config, event.error.createdIssue.id, callback)
+        @addCommentToIssue(config, event.error.createdIssue.id, @markdownBody(event))
+    else
+      @openIssue(config, event, callback)
 
 module.exports = PivotalTracker

--- a/plugins/pivotal-tracker/index.coffee
+++ b/plugins/pivotal-tracker/index.coffee
@@ -24,7 +24,7 @@ class PivotalTracker extends NotificationPlugin
 
   @ensureIssueOpen: (config, storyId, callback) ->
     @pivotalRequest(@request.put(@storyUrl(config, storyId)), config)
-      .send({"story[current_state]": "unstarted"})
+      .send({"story[current_state]": "unscheduled"})
       .on "error", (err) ->
         callback(err)
       .end (res) ->


### PR DESCRIPTION
Pivotal can have these bug types: `unscheduled`, `unstarted`, `started`, `finished`, `delivered`, `rejected` and `accepted`. By default they are `unscheduled`. They can be in different piles. So when an issue reoccurs, I just make it `unstarted` again, but preserve the pile. The piles are `icebox`, `backlog`, `current` (by default). A fresh issue starts at `icebox`. Then you can `start` it and that moves it to `current`. So if an issue is in any state and it reoccured, we just add a comment that mentions that.

It's worth mentioning that we support API v3. The latest version of API is v5.

![screenshot 2014-09-16 18 25 45](https://cloud.githubusercontent.com/assets/1079123/4297325/98498bce-3e09-11e4-8385-322c205608b1.png)