### PR TITLE
82 bitbucket

### DIFF
--- a/plugins/bitbucket-issues/config.json
+++ b/plugins/bitbucket-issues/config.json
@@ -34,6 +34,7 @@
       "type": "select",
       "allowedValues": ["bug", "task", "proposal", "enhancement"],
       "defaultValue": "bug",
+      "optional": true,
       "section": "tags"
     },
     {
@@ -43,6 +44,7 @@
       "type": "select",
       "allowedValues": ["blocker", "critical", "major", "minor", "trivial"],
       "defaultValue": "critical",
+      "optional": true,
       "section": "tags"
     }
   ]

--- a/plugins/bitbucket-issues/index.coffee
+++ b/plugins/bitbucket-issues/index.coffee
@@ -6,7 +6,7 @@ class BitbucketIssue extends NotificationPlugin
   BASE_URL = "https://bitbucket.org"
 
   @issuesUrl: (config) ->
-    "#{BASE_URL}/api/1.0/repositories/#{config.username}/#{config.repo}/issues"
+    "#{BASE_URL}/api/1.0/repositories/#{config.repo}/issues"
 
   @issueUrl: (config, issueId) ->
     @issuesUrl(config) + "/" + issueId
@@ -41,6 +41,7 @@ class BitbucketIssue extends NotificationPlugin
       "kind": config.kind
       "priority": config.priority
 
+    console.log @issuesUrl(config)
     # Send the request
     @bitbucketRequest(@request.post(@issuesUrl(config)), config)
       .send(qs.stringify(query_object))
@@ -51,7 +52,7 @@ class BitbucketIssue extends NotificationPlugin
 
         callback null,
           id: res.body.local_id
-          url: url.resolve(BASE_URL, "#{config.username}/#{config.repo}/issue/#{res.body.local_id}")
+          url: url.resolve(BASE_URL, "#{config.repo}/issue/#{res.body.local_id}")
 
   @receiveEvent: (config, event, callback) ->
     if event?.trigger?.type == "reopened"

--- a/plugins/bitbucket-issues/index.coffee
+++ b/plugins/bitbucket-issues/index.coffee
@@ -41,7 +41,6 @@ class BitbucketIssue extends NotificationPlugin
       "kind": config.kind
       "priority": config.priority
 
-    console.log @issuesUrl(config)
     # Send the request
     @bitbucketRequest(@request.post(@issuesUrl(config)), config)
       .send(qs.stringify(query_object))

--- a/plugins/bitbucket-issues/index.coffee
+++ b/plugins/bitbucket-issues/index.coffee
@@ -22,7 +22,7 @@ class BitbucketIssue extends NotificationPlugin
 
   @ensureIssueOpen: (config, issueId, callback) ->
     @bitbucketRequest(@request.put(@issueUrl(config, issueId)), config)
-      .send(qs.stringify({status: "open"}))
+      .send(qs.stringify({status: "new"}))
       .on "error", (err) ->
         callback(err)
       .end (res) ->

--- a/plugins/bitbucket-issues/index.coffee
+++ b/plugins/bitbucket-issues/index.coffee
@@ -4,9 +4,8 @@ qs = require 'qs'
 
 class BitbucketIssue extends NotificationPlugin
   BASE_URL = "https://bitbucket.org"
-  @receiveEvent: (config, event, callback) ->
-    return if event?.trigger?.type == "reopened"
 
+  @openIssue: (config, event, callback) ->
     query_object =
       "title": @title(event)
       "content": @markdownBody(event)
@@ -15,7 +14,7 @@ class BitbucketIssue extends NotificationPlugin
 
     # Send the request
     @request
-      .post(url.resolve(BASE_URL, "/api/1.0/repositories/#{config.repo}/issues"))
+      .post(url.resolve(BASE_URL, "/api/1.0/repositories/#{config.username}/#{config.repo}/issues"))
       .timeout(4000)
       .auth(config.username, config.password)
       .set('Accept', 'application/json')
@@ -28,5 +27,13 @@ class BitbucketIssue extends NotificationPlugin
         callback null,
           id: res.body.local_id
           url: url.resolve(BASE_URL, "#{config.repo}/issue/#{res.body.local_id}")
+
+  @receiveEvent: (config, event, callback) ->
+    if event?.trigger?.type == "reopened"
+      if event?.error?.createdIssue?.id
+        @ensureIssueOpen(config, event.error.createdIssue.id, callback)
+        @addCommentToIssue(config, event.error.createdIssue.id, @markdownBody(event))
+    else
+      @openIssue(config, event, callback)
 
 module.exports = BitbucketIssue


### PR DESCRIPTION
This patch also fixes this plugin. [It wasn't working](https://github.com/bugsnag/bugsnag-notification-plugins/commit/42531bf26dbbb4bf6db8fa57b6bceb03ee6049ac). Bitbucket issues can be "open" or "resolved", and they also have irrelevant statuses like "on hold", "wontfix", etc. The integration just sets an issue to "open".

![screenshot 2014-09-17 15 17 47](https://cloud.githubusercontent.com/assets/1079123/4312301/7fe8bdca-3eb8-11e4-9da6-b36f96a29294.png)
