### PR TITLE
[WIP] sprintly: implement reopening of issues

### DIFF
--- a/plugins/sprintly/index.coffee
+++ b/plugins/sprintly/index.coffee
@@ -2,14 +2,35 @@ NotificationPlugin = require "../../notification-plugin"
 qs = require 'qs'
 
 class Sprintly extends NotificationPlugin
-  @receiveEvent: (config, event, callback) ->
-    return if event?.trigger?.type == "reopened"
-    
-    user_email = config.sprintlyEmail
-    api_key = config.apiKey
-    project_id = config.projectId
-    sprintly_status = config.sprintlyStatus
+  BASE_URL = "https://sprint.ly/api/products"
 
+  @issuesUrl: (config) ->
+    "#{BASE_URL}/#{config.projectId}/items.json"
+
+  @issueUrl: (config, issueId) ->
+    "#{BASE_URL}/#{config.projectId}/items/#{issueId}.json"
+
+  @commentsUrl: (config, issueId) ->
+    "#{BASE_URL}/#{config.projectId}/items/#{issueId}/comments.json"
+
+  @sprintlyRequest: (req, config) ->
+    req.auth(config.sprintlyEmail, config.apiKey)
+
+  @ensureIssueOpen: (config, issueId, callback) ->
+    @sprintlyRequest(@request.post(@issueUrl(config, issueId)), config)
+      .send(qs.stringify({status: "in-progress"}))
+      .on "error", (err) ->
+        callback(err)
+      .end (res) ->
+        callback(res.error)
+
+  @addCommentToIssue: (config, issueId, comment) ->
+    @sprintlyRequest(@request.post(@commentsUrl(config, issueId)), config)
+      .send(qs.stringify({body: comment, type: "commit"}))
+      .on("error", console.error)
+      .end()
+
+  @openIssue: (config, event, callback) ->
     # Build the Sprint.ly API request
     # API documentation: https://sprintly.uservoice.com/knowledgebase/articles/98412-items
     description =
@@ -24,11 +45,9 @@ class Sprintly extends NotificationPlugin
       "title": "#{event.error.exceptionClass} in #{event.error.context}"
       "tags": "bugsnag"
       "description": description
-      "status": sprintly_status
+      "status": config.sprintlyStatus
 
-    @request
-      .post("https://sprint.ly/api/products/#{project_id}/items.json")
-      .auth(user_email, api_key)
+    @sprintlyRequest(@request.post(@issuesUrl(config)), config)
       .send(qs.stringify(query_object))
       .on "error", (err) ->
         callback(err)
@@ -38,5 +57,13 @@ class Sprintly extends NotificationPlugin
         callback null,
           number: res.body.number
           url: res.body.short_url
+
+  @receiveEvent: (config, event, callback) ->
+    if event?.trigger?.type == "reopened"
+      if event?.error?.createdIssue?.number
+        @ensureIssueOpen(config, event.error.createdIssue.number, callback)
+        @addCommentToIssue(config, event.error.createdIssue.number, @markdownBody(event))
+    else
+      @openIssue(config, event, callback)
 
 module.exports = Sprintly


### PR DESCRIPTION
Only `backlog`, `in-progress`, `completed`, and `accepted` are valid values for issues. We mark them as `in-progress`, when they reoccur.

![screenshot 2014-09-17 17 05 26](https://cloud.githubusercontent.com/assets/1079123/4313338/9640f5e2-3ec7-11e4-958d-c75af0b4751b.png)