### PR TITLE
Support for custom priorities [Fixes #132]

### DIFF
--- a/plugins/redmine-issues/config.json
+++ b/plugins/redmine-issues/config.json
@@ -32,9 +32,6 @@
       "name": "priority",
       "label": "Issue Priority",
       "description": "The priority of the issue to be created",
-      "type": "select",
-      "allowedValues": ["low", "normal", "high", "urgent", "immediate"],
-      "defaultValue": "normal",
       "section": "tags"
     }
   ]


### PR DESCRIPTION
Hello!

I'm not sure whether this is going to work straight off the bat, or whether it requires a migration. But, regardless, this adds support for custom priorities within Redmine. This should have been implemented originally, I don't know why I didn't.

The one thing to note, is the fact that the API that makes this possible is only available in versions of Redmine newer than 2.2.0 (which was released on the 18th of December 2012). Not sure if this is an issue, but if it is, I am happy to slightly tweak it, so legacy fallback is available (which should mean re-implementing the static `priorityMap` lookup table).

![Screenshot](http://cl.ly/image/00180C3J2Z1e/Image%202014-09-23%20at%209.32.57%20pm.png)

__Source: [Redmine Feature Request](http://www.redmine.org/issues/9835) and [Redmine Changelog](http://www.redmine.org/projects/redmine/wiki/Changelog_2_2)__