### PR TITLE
Add support for GitHub Enterprise [Fixes #116]

### DIFF
--- a/plugins/github-issues/config.json
+++ b/plugins/github-issues/config.json
@@ -47,6 +47,13 @@
       "optional": true,
       "defaultValue": false,
       "section": "labeling"
+    },
+    {
+      "name": "url",
+      "label": "URL",
+      "description": "The GitHub Enterprise URL (e.g. https://github.local/api/v3)",
+      "optional": true,
+      "section": "enterprise"
     }
   ]
 }

--- a/plugins/github-issues/index.coffee
+++ b/plugins/github-issues/index.coffee
@@ -1,9 +1,11 @@
 NotificationPlugin = require "../../notification-plugin"
 
 class GithubIssue extends NotificationPlugin
-  BASE_URL = "https://api.github.com"
+  DEFAULT_URL = "https://api.github.com"
 
-  @issuesUrl: (config) -> "#{BASE_URL}/repos/#{config.repo}/issues"
+  @githubUrl: (config) -> config.url or DEFAULT_URL
+
+  @issuesUrl: (config) -> "#{@githubUrl config}/repos/#{config.repo}/issues"
   @issueUrl: (config, issueNumber) -> "#{@issuesUrl(config)}/#{issueNumber}"
 
   @githubRequest: (req, config) ->


### PR DESCRIPTION
This adds an option to provide a GitHub Enterprise URL (endpoint), which is used instead of the default (api.github.com). For example; the url for my local GitHub Enterprise instance was `http://192.168.1.115/api/v3` - so the description reflects that format.

![Screenshot](http://i.imgur.com/hC8mTSE.png)