### PR TITLE
Add app/project name to uservoice

### DIFF
--- a/plugins/uservoice/index.coffee
+++ b/plugins/uservoice/index.coffee
@@ -10,16 +10,18 @@ class UserVoice extends NotificationPlugin
       client: config.apiKey
       email: "bugsnag@bugsnag.com"
       ticket:
-        subject: "#{event.error.exceptionClass} in #{event.error.context}"
+        subject: "[#{event.project.name}] #{event.error.exceptionClass} in #{event.error.context}"
         message:
           """
-          #{event.error.exceptionClass} in #{event.error.context}
+          #{event.error.exceptionClass} in #{event.error.context} for project #{event.project.name}
           #{event.error.message if event.error.message}
           #{event.error.url}
 
           Stacktrace:
           #{@basicStacktrace(event.error.stacktrace)}
           """
+        custom_field_values:
+          app: event.project.name
 
     # Send the request
     url = if config.url.startsWith(/https?:\/\//) then config.url else "https://#{config.url}"

--- a/plugins/uservoice/index.coffee
+++ b/plugins/uservoice/index.coffee
@@ -21,7 +21,7 @@ class UserVoice extends NotificationPlugin
           #{@basicStacktrace(event.error.stacktrace)}
           """
         custom_field_values:
-          app: event.project.name
+          bugsnagProjectName: event.project.name
 
     # Send the request
     url = if config.url.startsWith(/https?:\/\//) then config.url else "https://#{config.url}"


### PR DESCRIPTION
# Problem

Need to be able to route tickets to queues based on the app that generated the issue.

# Solution

There are three things in here, and any one of them is probably fine:
* project name in subject
* project name in message
* project name in `app` custom field

I have no idea how to execute or test this, so hopefully someone can let me know if this is right