### PR TITLE
[Target Process] Support for specifying Team

### DIFF
--- a/plugins/target-process/config.json
+++ b/plugins/target-process/config.json
@@ -32,6 +32,13 @@
       "label": "Project Id",
       "description": "Your project's unique id, e.g. 190",
       "section": "authentication"
+    },
+    {
+      "name": "teamId",
+      "label": "Team Id",
+      "description": "The team (id) you wish to assign to all errors",
+      "section": "advanced",
+      "optional": true
     }
   ]
 }

--- a/plugins/target-process/index.coffee
+++ b/plugins/target-process/index.coffee
@@ -13,9 +13,15 @@ module.exports = class TargetProcess extends NotificationPlugin
 
   # Build the request payload
   @requestPayload = (config, event) ->
-    name: @title event
-    description: @htmlBody event
-    project: id: config.projectId
+    payload =
+      name: @title event
+      description: @htmlBody event
+      project: id: config.projectId
+
+    # If a teamId is specified, add it to the payload
+    payload.team = id: config.teamId if config.teamId?
+
+    payload
 
   # Receive the configuration & event payload
   @receiveEvent = (config, event, callback) ->


### PR DESCRIPTION
Adds support for specifying a team, which is assigned to all the errors going through to Target Process.

There is time for minor tweaks, such as - providing a team name instead. I opted for using the ID because of potential naming conflicts (in favour of being rather verbose).

![Screenshot](https://www.dropbox.com/s/7zuerkqbl5bhcpc/Screenshot%202014-12-13%2010.06.14.png?dl=1)

PS. I miss you guys. And merry christmas!