### PR TITLE
Allow pagerduty to de-dupe events.

### DIFF
--- a/plugins/pagerduty/index.coffee
+++ b/plugins/pagerduty/index.coffee
@@ -24,7 +24,8 @@ class PagerDuty extends NotificationPlugin
       payload =
         service_key: config.serviceKey
         event_type: 'trigger'
-        incident_key: event.error.url
+        # Use error url without unique event key to allow pagerduty to de-dupe
+        incident_key: event.error.url.split('?')[0]
         description: "#{event.error.exceptionClass} in #{event.error.context}"
         details: pagerDutyDetails(event)
 


### PR DESCRIPTION
If the same exception fires many times before a pagerduty incident is resolved then it currently creates multiple pages. This change allows pagerduty to de-dupe and only have one open page based on the grouping in bugsnag.

The relevant pagerduty documentation is available here: https://developer.pagerduty.com/documentation/integration/events/trigger