### PR TITLE
add jira config to prevent re-opening issues

### DIFF
--- a/plugins/jira/config.json
+++ b/plugins/jira/config.json
@@ -55,6 +55,14 @@
       "type": "json",
       "optional": true,
       "section": "fields"
+    },
+    {
+      "name": "reopenIssues",
+      "label": "Re-open Closed Issues",
+      "description": "Whether or not bugsnag should re-open issues that have been closed in JIRA. If disabled, bugsnag will still comment on an issue if it re-occurs.",
+      "defaultValue": true,
+      "type": "boolean",
+      "section": "behavior"
     }
   ]
 }

--- a/plugins/jira/index.coffee
+++ b/plugins/jira/index.coffee
@@ -113,7 +113,7 @@ class Jira extends NotificationPlugin
   @receiveEvent: (config, event, callback) ->
     if event?.trigger?.type == "reopened"
       if event?.error?.createdIssue?.id
-        @ensureIssueOpen(config, event.error.createdIssue.id, callback)
+        @ensureIssueOpen(config, event.error.createdIssue.id, callback) unless not config.reopenIssues
         @addCommentToIssue(config, event.error.createdIssue.id, jiraBody(event), callback)
     else
       @openIssue(config, event, callback)


### PR DESCRIPTION
This PR adds a new configuration in the JIRA plugin that disables re-opening issues when they re-occur.

This is useful in workflows where tickets are marked "resolved" before they are pushed live.
