### PR TITLE
Fix redmine-issues plugin

### DIFF
--- a/plugins/redmine-issues/index.coffee
+++ b/plugins/redmine-issues/index.coffee
@@ -77,10 +77,10 @@ class Redmine extends NotificationPlugin
         .end handleCallback
 
     # Fetch the priority and tracker id, and then handle the request
-    @fetchPriorityId config, config.priority, (err, priorityId) ->
+    @fetchPriorityId config, config.priority, (err, priorityId) =>
       return callback err if err
       unless config.tracker.nil?
-        @fetchTrackerId config, config.tracker (err, trackerId) ->
+        @fetchTrackerId config, config.tracker, (err, trackerId) ->
           return callback err if err
           handleRequest priorityId, trackerId
       else


### PR DESCRIPTION
When trying to create test issues from Bugsnag "Issue Tracker" setting screen I got 408 timeout responses.
Our Redmine API is working fine from other REST clients.
It seems to be coming from a TypeError and ReferenceError from the plugin.

The first stacktrace I got was :

```
[~/src/bugsnag-notification-plugins/plugins/redmine-issues (master * u=)]$ ../../node_modules/.bin/coffee index.coffee --host=https://example.com --apiKey=<key> --project=project-slug --priority=Normal --tracker=Bug

/Users/msadouni/src/bugsnag-notification-plugins/plugins/redmine-issues/index.coffee:106
          return this.fetchTrackerId(config, config.tracker(function(err, trac
                                                    ^
TypeError: Property 'tracker' of object #<Object> is not a function
  at /Users/msadouni/src/bugsnag-notification-plugins/plugins/redmine-issues/index.coffee:83:40
  at /Users/msadouni/src/bugsnag-notification-plugins/plugins/redmine-issues/index.coffee:36:13
  at Request.callback (/Users/msadouni/src/bugsnag-notification-plugins/node_modules/superagent/lib/node/index.js:586:3)
  at Request.<anonymous> (/Users/msadouni/src/bugsnag-notification-plugins/node_modules/superagent/lib/node/index.js:133:10)
  at Request.EventEmitter.emit (events.js:95:17)
  at IncomingMessage.<anonymous> (/Users/msadouni/src/bugsnag-notification-plugins/node_modules/superagent/lib/node/index.js:714:12)
  at IncomingMessage.EventEmitter.emit (events.js:117:20)
  at _stream_readable.js:920:16
  at process._tickCallback (node.js:415:13)
```

After adding a missing comma I got :

```
/Users/msadouni/src/bugsnag-notification-plugins/plugins/redmine-issues/index.coffee:106
          return this.fetchTrackerId(config, config.tracker, function(err, tra
                      ^
TypeError: Object #<Object> has no method 'fetchTrackerId'
  at /Users/msadouni/src/bugsnag-notification-plugins/plugins/redmine-issues/index.coffee:83:10
  at /Users/msadouni/src/bugsnag-notification-plugins/plugins/redmine-issues/index.coffee:36:13
  at Request.callback (/Users/msadouni/src/bugsnag-notification-plugins/node_modules/superagent/lib/node/index.js:586:3)
  at Request.<anonymous> (/Users/msadouni/src/bugsnag-notification-plugins/node_modules/superagent/lib/node/index.js:133:10)
  at Request.EventEmitter.emit (events.js:95:17)
  at IncomingMessage.<anonymous> (/Users/msadouni/src/bugsnag-notification-plugins/node_modules/superagent/lib/node/index.js:714:12)
  at IncomingMessage.EventEmitter.emit (events.js:117:20)
  at _stream_readable.js:920:16
  at process._tickCallback (node.js:415:13)
```

I don't know CoffeeScript but it seems to be the same issue you get in Javascript when you need to call `this` in a closure and you have to `var that = this;` before. CoffeeScript apparently uses fat arrows to do that, so I tried and it worked, the test issue appears in Redmine.