### PR TITLE
Stacktrace + HTTPS URLs

### DIFF
--- a/plugins/xmatters/config.json
+++ b/plugins/xmatters/config.json
@@ -10,7 +10,7 @@
       "name": "form",
       "label": "Form URL",
       "description": "Your xMatters BugSnag Integration form",
-      "pattern": "http?:\/\/.+",
+      "pattern": "https?:\/\/.+",
       "section": "authentication"
     },
     {

--- a/plugins/xmatters/index.coffee
+++ b/plugins/xmatters/index.coffee
@@ -6,8 +6,10 @@ class xMatters extends NotificationPlugin
   flatten = (dstObj, srcObj, prefix) ->     
     for property of srcObj
       if typeof srcObj[property] == "object"
-        if prefix 
-          continue	# nested objects like stackTrace array are not supported
+        # for stacktrace, pick first object
+        if property == "stacktrace" && srcObj[property].length > 0
+          flatten(dstObj, srcObj[property][0], property)
+        continue if prefix	# other nested objects are not supported
         flatten(dstObj, srcObj[property], property)
       else if prefix 
         dstObj[ prefix + "." + property] = srcObj[property] 


### PR DESCRIPTION
Most form URLs in xMatters have HTTPS prefix. This update enables these.