### PR TITLE
Proxy support for notifications

### DIFF
--- a/notification-plugin.coffee
+++ b/notification-plugin.coffee
@@ -35,6 +35,14 @@ module.exports = class NotificationPlugin
 
   # Utility methods for http requests
   @request = require "superagent"
+  if process.env.NOTIFICATIONS_PROXY
+    # If we have a configured proxy monkey patch it in so clients dont need to know
+    require('superagent-proxy')(@request)
+
+    ["post", "get", "delete", "head", "put"].forEach (verb) =>
+      original = @request[verb]
+      @request[verb] = (args...) ->
+        original(args...).proxy(process.env.NOTIFICATIONS_PROXY)
 
   # Fired when a new event is triggered for notification
   # Plugins MUST override this method

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "optimist": "~0.3.5",
     "qs": "~0.6.6",
     "sugar": "~1.3.8",
-    "superagent": "~0.13.0",
+    "superagent": "^1.2.0",
+    "superagent-proxy": "^0.3.2",
     "xml2js": "~0.2.6",
     "xmlrpc": "^1.2.0"
   },

--- a/plugins/hipchat/index.coffee
+++ b/plugins/hipchat/index.coffee
@@ -48,10 +48,11 @@ class Hipchat extends NotificationPlugin
         .set("Content-Type", "application/json")
         .timeout(4000)
         .send(payload)
-        .on "error", (err) ->
-          callback(err)
-        .end (res) ->
-          callback(res.error)
+        .end (error, response) ->
+          if error?.response?.text
+            callback(JSON.parse(error.response.text).error?.message)
+          else
+            callback()
 
     else
       payload.room_id = config.roomId
@@ -61,10 +62,11 @@ class Hipchat extends NotificationPlugin
         .type("form")
         .timeout(4000)
         .send(payload)
-        .on "error", (err) ->
-          callback(err)
-        .end (res) ->
-          callback(res.error)
+        .end (error, response) ->
+          if error?.response?.text
+            callback(JSON.parse(error.response.text).error?.message)
+          else
+            callback()
 
 
   @render: Handlebars.compile(


### PR DESCRIPTION
This means we can use a proxy for notifications.

I need to test every plugin because I had to massively upgrade superagent and the API has definitely changed. I'll also use this to try and get better error messages for the user too.

Hipchat only done so far.
