### PR TITLE
Support Jira installations that are inside directories

### DIFF
--- a/plugins/jira/index.coffee
+++ b/plugins/jira/index.coffee
@@ -21,7 +21,7 @@ class Jira extends NotificationPlugin
     """
 
   @baseUrl: (config) ->
-    url.resolve(config.host, "/rest/api/2")
+    url.resolve(config.host, "rest/api/2")
 
   @issuesUrl: (config) ->
     @baseUrl(config) + "/issue"


### PR DESCRIPTION
Stop requiring Jira installations to exist at the root of the domain
entered into the "Host" config field. Before this change, a Host
configuration of "https://mydomain.com/tools/jira/" would be treated
exactly the same as "https://mydomain.com".

After this change, URLs will be resolved from the last forward slash
given in the "Host" config field. THAT MEANS YOU HAVE TO PUT A TRAILING
SLASH ON YOUR HOST URLS IF THEY ARE NOT BARE DOMAINS.