### PR TITLE
More descriptive labels for GitHub Enterprise configuration

### DIFF
--- a/plugins/github-issues/config.json
+++ b/plugins/github-issues/config.json
@@ -51,9 +51,9 @@
     {
       "name": "url",
       "label": "URL",
-      "description": "The GitHub Enterprise URL (e.g. https://github.local)",
+      "description": "Your GitHub Enterprise URL (e.g. https://github.local). Leave blank for github.com.",
       "optional": true,
-      "section": "enterprise"
+      "section": "GitHub Enterprise"
     }
   ]
 }


### PR DESCRIPTION
If you're not a GHE user, the "Enterprise" section can be a little confusing. It's not entirely obvious that you can leave the field blank to default to github.com. This PR updates the placeholder and section title in an effort to make it a little more clear what to add here.

cc @neverett 